### PR TITLE
feat: invite links for trip sharing with role selection (Closes #8)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -157,6 +157,15 @@ db.exec(`
     FOREIGN KEY (user_id) REFERENCES users(id)
   );
   CREATE INDEX IF NOT EXISTS idx_trip_members_user ON trip_members(user_id);
+
+  CREATE TABLE IF NOT EXISTS invite_tokens (
+    token TEXT PRIMARY KEY,
+    trip_id TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('participant', 'viewer')),
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE
+  );
+  CREATE INDEX IF NOT EXISTS idx_invite_tokens_trip ON invite_tokens(trip_id);
 `);
 
 // Migrations: add new columns to trips if missing

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ProfilePage from './pages/ProfilePage';
 import SharePage from './pages/SharePage';
+import InvitePage from './pages/InvitePage';
 import './App.css';
 
 /** When API is enabled, requires login; otherwise renders children. */
@@ -58,6 +59,7 @@ function AppContent() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/share/:token" element={<SharePage />} />
+          <Route path="/invite/:token" element={<InvitePage />} />
           <Route element={<ProtectedRoute />}>
             <Route path="/" element={<Home />} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -180,6 +180,13 @@ export const api = {
     fetchJson<ApiState['pinnedPlaces'][0]>(`/api/trips/${tripId}/pinned-places`, { method: 'POST', body: JSON.stringify(body) }),
   deletePinnedPlace: (id: string) => fetchJson<void>(`/api/pinned-places/${id}`, { method: 'DELETE' }),
 
+  createInviteToken: (tripId: string, role: 'participant' | 'viewer') =>
+    fetchJson<{ token: string; role: string }>(`/api/trips/${tripId}/invite`, { method: 'POST', body: JSON.stringify({ role }) }),
+  getInviteInfo: (token: string) =>
+    fetchJsonPublic<{ tripId: string; tripName: string; destination?: string; startDate: string; endDate: string; role: string }>(`/api/invite/${token}`),
+  acceptInvite: (token: string) =>
+    fetchJson<{ ok: boolean; tripId: string }>(`/api/invite/${token}/accept`, { method: 'POST' }),
+
   getFlights: (tripId: string) => fetchJson<NonNullable<ApiState['flights']>>(`/api/trips/${tripId}/flights`),
   createFlight: (tripId: string, body: Omit<import('../types').Flight, 'id'>) =>
     fetchJson<import('../types').Flight>(`/api/trips/${tripId}/flights`, { method: 'POST', body: JSON.stringify(body) }),

--- a/frontend/src/pages/InvitePage.tsx
+++ b/frontend/src/pages/InvitePage.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { api, isApiEnabled } from '../api/client';
+import { useAuth } from '../context/AuthContext';
+
+export default function InvitePage() {
+  const { token } = useParams<{ token: string }>();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [info, setInfo] = useState<{ tripName: string; destination?: string; startDate: string; endDate: string; role: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+  const [accepted, setAccepted] = useState(false);
+
+  useEffect(() => {
+    if (!token || !isApiEnabled()) return;
+    api.getInviteInfo(token)
+      .then(setInfo)
+      .catch(() => setError('קישור ההזמנה לא נמצא או שפג תוקפו'));
+  }, [token]);
+
+  const handleAccept = async () => {
+    if (!token) return;
+    setAccepting(true);
+    try {
+      const result = await api.acceptInvite(token);
+      setAccepted(true);
+      setTimeout(() => navigate(`/trip/${result.tripId}`), 1500);
+    } catch {
+      setError('שגיאה בקבלת ההזמנה');
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const roleLabel = (r: string) => r === 'participant' ? 'משתתף (עריכה)' : 'צופה (קריאה בלבד)';
+
+  if (error) {
+    return (
+      <div dir="rtl" className="page-wrap">
+        <p style={{ color: 'var(--color-danger)' }}>{error}</p>
+        <Link to="/">דף בית</Link>
+      </div>
+    );
+  }
+
+  if (!info) {
+    return <div dir="rtl" className="page-wrap"><p>טוען...</p></div>;
+  }
+
+  return (
+    <div dir="rtl" className="page-wrap">
+      <h1>הזמנה לטיול</h1>
+      <div className="card" style={{ padding: 'var(--space-lg)' }}>
+        <h2 style={{ marginTop: 0 }}>{info.tripName}</h2>
+        {info.destination && <p><strong>יעד:</strong> {info.destination}</p>}
+        <p><strong>תאריכים:</strong> {info.startDate} – {info.endDate}</p>
+        <p><strong>תפקיד:</strong> {roleLabel(info.role)}</p>
+
+        {accepted ? (
+          <p style={{ color: 'var(--color-success, green)' }}>הצטרפת לטיול! מעביר אותך...</p>
+        ) : user ? (
+          <button type="button" onClick={handleAccept} disabled={accepting} className="btn btn-primary">
+            {accepting ? 'מצטרף...' : 'הצטרף לטיול'}
+          </button>
+        ) : (
+          <div>
+            <p>כדי להצטרף לטיול, יש להתחבר או להירשם קודם.</p>
+            <p className="btn-group">
+              <Link to="/login" className="btn btn-primary" style={{ textDecoration: 'none' }}>התחבר</Link>
+              <Link to="/register" className="btn btn-secondary" style={{ textDecoration: 'none' }}>הירשם</Link>
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary\n\n- **Invite tokens**: Owner can generate a shareable invite link with a role (participant/viewer)\n- **Accept flow**: /invite/:token page shows trip info; logged-in users can accept and auto-join; non-logged users see login/register links\n- **Share via**: copy link, email (mailto), WhatsApp buttons in the members modal\n- Backend: invite_tokens table, 3 new endpoints\n- Frontend: InvitePage component, updated TripMembersModal\n\nAll 29 tests pass.