### PR TITLE
fix: PDF export garbled Hebrew — load Hebrew font at runtime (Closes #20)

### DIFF
--- a/frontend/src/pages/Trip.tsx
+++ b/frontend/src/pages/Trip.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { jsPDF } from 'jspdf';
+import { registerHebrewFont } from '../utils/pdfFont';
 import { useTripData } from '../context/TripContext';
 import DayMap, { type MapPoint } from '../components/DayMap';
 import LocationPickerMap from '../components/LocationPickerMap';
@@ -211,9 +212,10 @@ export default function Trip() {
     const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = `${exportFileName}.txt`; a.click(); URL.revokeObjectURL(a.href);
     setShowExportDialog(false);
   };
-  const handleExportPdf = () => {
+  const handleExportPdf = async () => {
     const text = buildTripAsText(trip, days, allActivities, accommodations, attractions, shoppingItems, flights);
     const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+    await registerHebrewFont(doc);
     doc.setR2L(true);
     const pageW = (doc as unknown as { getPageWidth?: () => number }).getPageWidth?.() ?? doc.internal.pageSize.getWidth();
     const pageH = (doc as unknown as { getPageHeight?: () => number }).getPageHeight?.() ?? doc.internal.pageSize.getHeight();

--- a/frontend/src/utils/pdfFont.ts
+++ b/frontend/src/utils/pdfFont.ts
@@ -1,0 +1,39 @@
+import { jsPDF } from 'jspdf';
+
+const FONT_URL =
+  'https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/rubik/static/Rubik-Regular.ttf';
+const FONT_NAME = 'Rubik';
+const FONT_FILE = 'Rubik-Regular.ttf';
+
+let cachedBase64: string | null = null;
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Fetches a Hebrew-supporting TTF font and registers it with jsPDF.
+ * Caches the font in memory so subsequent calls are instant.
+ * Returns true if the font was registered, false on failure.
+ */
+export async function registerHebrewFont(doc: jsPDF): Promise<boolean> {
+  try {
+    if (!cachedBase64) {
+      const res = await fetch(FONT_URL);
+      if (!res.ok) return false;
+      const buf = await res.arrayBuffer();
+      cachedBase64 = arrayBufferToBase64(buf);
+    }
+    doc.addFileToVFS(FONT_FILE, cachedBase64);
+    doc.addFont(FONT_FILE, FONT_NAME, 'normal');
+    doc.setFont(FONT_NAME);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- jsPDF's default Helvetica font has no Hebrew glyphs, producing garbled PDF output
- Added `utils/pdfFont.ts` that fetches the Rubik TTF font from Google Fonts CDN at export time
- Font is cached in memory so subsequent exports are instant
- Falls back gracefully if font fetch fails

Closes #20

## Test plan
- [x] All 19 frontend tests pass
- [ ] Export a trip with Hebrew text to PDF and verify readable output
