### PR TITLE
fix: blank page on refresh — add ErrorBoundary and loading states (Closes #21)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Link, Navigate, useLocation, Outlet } from 'react-router
 import { TripProvider } from './context/TripContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { isApiEnabled } from './api/client';
+import ErrorBoundary from './components/ErrorBoundary';
 import Home from './pages/Home';
 import Trip from './pages/Trip';
 import DayView from './pages/DayView';
@@ -76,11 +77,13 @@ function AppContent() {
 
 function App() {
   return (
-    <AuthProvider>
-      <TripProvider>
-        <AppContent />
-      </TripProvider>
-    </AuthProvider>
+    <ErrorBoundary>
+      <AuthProvider>
+        <TripProvider>
+          <AppContent />
+        </TripProvider>
+      </AuthProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+type Props = { children: ReactNode };
+type State = { hasError: boolean; error: Error | null };
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  handleReload = () => {
+    this.setState({ hasError: false, error: null });
+    window.location.href = '/';
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div dir="rtl" style={{ textAlign: 'center', padding: '4rem 1rem', maxWidth: 480, margin: '0 auto' }}>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>משהו השתבש</h1>
+          <p style={{ color: '#64748b', marginBottom: '1.5rem' }}>
+            אירעה שגיאה בטעינת הדף. נסה לרענן או לחזור לדף הבית.
+          </p>
+          <button
+            type="button"
+            onClick={this.handleReload}
+            style={{
+              padding: '10px 24px',
+              fontSize: '1rem',
+              borderRadius: '10px',
+              border: 'none',
+              background: '#2563eb',
+              color: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            חזרה לדף הבית
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/pages/DayView.tsx
+++ b/frontend/src/pages/DayView.tsx
@@ -27,6 +27,7 @@ export default function DayView() {
   const { id, dayIndex: dayIndexParam } = useParams<{ id: string; dayIndex: string }>();
   const dayIndex = dayIndexParam != null ? parseInt(dayIndexParam, 10) : NaN;
   const {
+    loadingState,
     getTrip,
     getDays,
     getActivitiesForDay,
@@ -77,11 +78,21 @@ export default function DayView() {
     );
   }
 
-  if (!trip) {
+  if (!trip && loadingState === 'done') {
     return (
       <div dir="rtl" className="page-wrap">
         <p>הטיול לא נמצא</p>
         <Link to="/">דף בית</Link>
+      </div>
+    );
+  }
+
+  if (!trip) {
+    return (
+      <div dir="rtl" className="page-wrap">
+        <h1>טוען...</h1>
+        <div className="skeleton" style={{ height: 80, borderRadius: 'var(--radius-lg)', marginBottom: 'var(--space-md)' }} />
+        <div className="skeleton" style={{ height: 200, borderRadius: 'var(--radius-lg)' }} />
       </div>
     );
   }

--- a/frontend/src/pages/EditTripPage.tsx
+++ b/frontend/src/pages/EditTripPage.tsx
@@ -4,7 +4,7 @@ import { useTripData } from '../context/TripContext';
 
 export default function EditTripPage() {
   const { id } = useParams<{ id: string }>();
-  const { getTrip, updateTrip } = useTripData();
+  const { loadingState, getTrip, updateTrip } = useTripData();
   const navigate = useNavigate();
   const trip = id ? getTrip(id) : undefined;
 
@@ -15,11 +15,20 @@ export default function EditTripPage() {
   const [tagsStr, setTagsStr] = useState((trip?.tags ?? []).join(', '));
   const [budget, setBudget] = useState(trip?.budget ?? '');
 
-  if (!trip) {
+  if (!trip && loadingState === 'done') {
     return (
       <div dir="rtl" className="page-wrap">
         <p>טיול לא נמצא.</p>
         <Link to="/">חזרה לרשימת הטיולים</Link>
+      </div>
+    );
+  }
+
+  if (!trip) {
+    return (
+      <div dir="rtl" className="page-wrap">
+        <h1>טוען...</h1>
+        <div className="skeleton" style={{ height: 300, borderRadius: 'var(--radius-lg)' }} />
       </div>
     );
   }

--- a/frontend/src/pages/Trip.tsx
+++ b/frontend/src/pages/Trip.tsx
@@ -18,6 +18,7 @@ export default function Trip() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const {
+    loadingState,
     getTrip, getDays,
     getAccommodationsForTrip, getAttractionsForTrip, getActivitiesForTrip,
     addAccommodation, addAttraction,
@@ -101,11 +102,21 @@ export default function Trip() {
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [showMembersModal, setShowMembersModal] = useState(false);
 
-  if (!id || !trip) {
+  if (!id || (!trip && loadingState === 'done')) {
     return (
       <div dir="rtl" className="page-wrap">
         <p>טיול לא נמצא</p>
         <Link to="/">דף בית</Link>
+      </div>
+    );
+  }
+
+  if (!trip) {
+    return (
+      <div dir="rtl" className="page-wrap">
+        <h1>טוען טיול...</h1>
+        <div className="skeleton" style={{ height: 120, borderRadius: 'var(--radius-lg)', marginBottom: 'var(--space-md)' }} />
+        <div className="skeleton" style={{ height: 200, borderRadius: 'var(--radius-lg)' }} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- On refresh, Trip/DayView/EditTrip pages showed "not found" before API data loaded → appeared as blank/broken page
- Now these pages show a skeleton loader while `loadingState` is not `'done'`, and only show "not found" after data has fully loaded
- Added a global `ErrorBoundary` component wrapping the entire app — catches unhandled render errors and shows a recovery UI with a "back to home" button instead of a white screen

Closes #21

## Test plan
- [x] All 19 frontend + 10 backend tests pass
- [ ] Refresh on `/trip/:id` page — should show skeleton then trip content
- [ ] Refresh on `/trip/:id/day/:dayIndex` — should show skeleton then day content
- [ ] Refresh on `/trip/:id/edit` — should show skeleton then edit form
